### PR TITLE
Added scan path argument

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -6,4 +6,5 @@
 git submodule update --init --recursive
 
 # Invoke CodeQL analysis
-python3 ./src/static/codeql/scripts/codeql.py --clean --builtin
+# If the SCAN_PATH env variable is not set, the argument will be ignored
+python3 ./src/static/codeql/scripts/codeql.py --clean --builtin --scan_path=$SCAN_PATH


### PR DESCRIPTION
`scan_path` argument allows the user to specify which directory to perform a CodeQL scan on.